### PR TITLE
Task #9 - add code coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- The ant build sets up debugging information like this, but we need even more details for jacoco -->
         <maven.compiler.debug>true</maven.compiler.debug>
         <maven.compiler.debuglevel>lines,source</maven.compiler.debuglevel>
         <maven.compiler.source>1.7</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- The ant build sets up debugging information like this, but we need even more details for jacoco -->
         <maven.compiler.debug>true</maven.compiler.debug>
         <maven.compiler.debuglevel>lines,source</maven.compiler.debuglevel>
         <maven.compiler.source>1.7</maven.compiler.source>
@@ -110,6 +111,25 @@
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>2.8.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.7.6.201602180812</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <phase>prepare-package</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -131,6 +151,10 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fixes #9 - added the jacoco-maven-plugin plugin to the parent pom so it's available for all modules
